### PR TITLE
detect findUniqueOrThrow small fixes

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
@@ -327,7 +327,7 @@ mod singular_batch {
             res.to_string(),
             @r###"{"batchResult":[{"data":{"findUniqueTestModelOrThrow":{"id":1}}},{"data":{"findUniqueTestModelOrThrow":{"id":2}}}]}"###
         );
-        // assert!(!compact_doc.is_compact());
+        assert!(compact_doc.is_compact());
 
         // Failing case
         let (res, compact_doc) = compact_batch(
@@ -338,11 +338,11 @@ mod singular_batch {
             ],
         )
         .await?;
-        // insta::assert_snapshot!(
-        //   res.to_string(),
-        //   @r###"{"batchResult":[{"data":{"findUniqueTestModelOrThrow":{"id":2}}},{"errors":[{"error":"Error occurred during query execution:\nConnectorError(ConnectorError { user_facing_error: Some(KnownError { message: \"An operation failed because it depends on one or more records that were required but not found. Expected a record, found none.\", meta: Object {\"cause\": String(\"Expected a record, found none.\")}, error_code: \"P2025\" }), kind: RecordDoesNotExist, transient: false })","user_facing_error":{"is_panic":false,"message":"An operation failed because it depends on one or more records that were required but not found. Expected a record, found none.","meta":{"cause":"Expected a record, found none."},"error_code":"P2025"}}]}]}"###
-        // );
-        // assert!(!compact_doc.is_compact());
+        insta::assert_snapshot!(
+          res.to_string(),
+          @r###"{"batchResult":[{"data":{"findUniqueTestModelOrThrow":{"id":2}}},{"errors":[{"error":"An operation failed because it depends on one or more records that were required but not found. Expected a record, found none.","user_facing_error":{"is_panic":false,"message":"An operation failed because it depends on one or more records that were required but not found. Expected a record, found none.","meta":{"cause":"Expected a record, found none."},"error_code":"P2025"}}]}]}"###
+        );
+        assert!(compact_doc.is_compact());
 
         // Mix of findUnique & findUniqueOrThrow
         let (res, compact_doc) = compact_batch(

--- a/query-engine/core/src/query_graph/guard.rs
+++ b/query-engine/core/src/query_graph/guard.rs
@@ -12,8 +12,7 @@ impl<T> Guard<T> {
     }
 
     pub fn unset(&mut self) -> T {
-        let content = std::mem::replace(&mut self.content, None);
-        match content {
+        match self.content.take() {
             Some(c) => c,
             None => panic!("Logic error: Attempted to unset empty graph guard."),
         }


### PR DESCRIPTION
These are a set of fixes from your PR at https://github.com/prisma/prisma-engines/pull/4014, which was already really good. 

I will answer your questions in https://github.com/prisma/prisma-engines/pull/4014#issuecomment-1572754544 here too:



> 1. When mapping the findMany back to the findUniqueOrThrow payloads, we need to insert an error response, but I was having a hard time figuring out how to generate the correct error here (lots of wrapping and indirection in the various error types/enums).
    * I didn't try to hard to verify this, but it looks like `findUnique` with `rejectOnUnauthorized` would just return null, and create the error in the client, I assume that for `findUniqueOrThrow` the error message is intended to come from the engine instead of the client?
    
As long as the `user_facing_error` part is correct, given we are not treating the error internally before returning, it's OK, the client will make use of that portion of the error, so I simplified the error expression in the handler code 


> 2.  In `CompactDocument` we need to track if the original queries were using `findUnique` or `findUniqueOrThrow` for 2 reasons: we need to have the single field name to map back to, and we need to know if we should insert an error or just a null result when a result is missing
>    * I am currently assuming that findUniqueOrThrow and findUnique are batched separately.  The batch ids generated, I think will be different between these 2 methods, so batching these together would also require client changes
>    * tracking this per query rather than per batch would add more complexity, and not sure if this would be worth the added complexity
    
  For the moment, the proposed level of optimization looks good, let's leave it this way and not try to batch different kind of operations for the moment.  
    
>    * This is currently tracked as a `suffix` string.  This feels a bit hacky, but I have not written a ton of rust, and am not familiar enough with this code base to know the best way to track that state

I changed that to, instead to use a heap allocated string, use a `QueryOptions` bitflag byte, which was also used in other parts of the crate.

3. The regression test for the issue you mentioned explicitly check that things shouldn't be batched. I think it should be safe to update the test to allow batching, as long as the response doesn't change (it currently does because the errors are not being generated correctly), but want to confirm my understanding of the issue was correct before changing that

I think that's an OK assumption.

Please let me know how the proposed changes below look into your proposed patch, and if you decide to merge them, we can follow-up with them.
